### PR TITLE
Fix x64 building

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,10 @@ source:
     fn: flann-{{ version }}.tar.gz
     url: https://github.com/mariusmuja/flann/archive/{{ version }}.tar.gz
     md5: 774b74580e3cbc5b0d45c6ec345a64ae
+    
+    patches:
+      # Borrowed from https://github.com/mariusmuja/flann/issues/82
+      - win64_serialization.patch  # [win64]
 
 build:
     number: 1

--- a/recipe/win64_serialization.patch
+++ b/recipe/win64_serialization.patch
@@ -1,0 +1,12 @@
+--- src/cpp/flann/util/serialization.h
++++ src/cpp/flann/util/serialization.h
+@@ -89,6 +89,9 @@
+ BASIC_TYPE_SERIALIZER(float);
+ BASIC_TYPE_SERIALIZER(double);
+ BASIC_TYPE_SERIALIZER(bool);
++#ifdef _MSC_VER
++BASIC_TYPE_SERIALIZER(unsigned __int64);
++#endif
+ 
+ 
+ // serializer for std::vector


### PR DESCRIPTION
Problem is known to Flann developer and just hasn't accepted
this patch. This poses a problem because serialized files
are thus not transferable between 32bit and 64bit machines -
but this is well known apparently.
